### PR TITLE
fix: add workaround for small fireball griefing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ repositories {
 }
 
 // Mod information.
-version = "1.16.5-9.0.0"
+version = "1.16.5-9.0.1"
 group = "com.judge40.minecraft.bettermobgriefinggamerule"
 archivesBaseName = "bettermobgriefinggamerule"
 

--- a/src/main/java/com/judge40/minecraft/bettermobgriefinggamerule/common/MobGriefingEventHandler.java
+++ b/src/main/java/com/judge40/minecraft/bettermobgriefinggamerule/common/MobGriefingEventHandler.java
@@ -21,6 +21,7 @@ package com.judge40.minecraft.bettermobgriefinggamerule.common;
 
 import com.judge40.minecraft.bettermobgriefinggamerule.common.world.EntityMobGriefingData;
 import net.minecraft.entity.Entity;
+import net.minecraft.entity.projectile.SmallFireballEntity;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.world.GameRules;
@@ -48,6 +49,15 @@ public class MobGriefingEventHandler {
     Entity griefingEntity = mobGriefingEvent.getEntity();
 
     if (griefingEntity != null) {
+      // TODO: Workaround for MinecraftForge bug, remove when PR #9038 merged.
+      if (griefingEntity instanceof SmallFireballEntity) {
+        Entity owner = ((SmallFireballEntity) griefingEntity).getOwner();
+
+        if (owner != null) {
+          griefingEntity = owner;
+        }
+      }
+
       if (isMobGriefingEnabled(griefingEntity)) {
         mobGriefingEvent.setResult(Result.ALLOW);
       } else {

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -6,7 +6,7 @@ license="MIT"
 
 [[mods]]
 modId="bettermobgriefinggamerule"
-version="1.16.5-9.0.0"
+version="1.16.5-9.0.1"
 displayName="Better mobGriefing GameRule"
 updateJSONURL="https://github.com/Judge40/BetterMobGriefingGameRule/update.json"
 displayURL="https://github.com/Judge40/BetterMobGriefingGameRule"

--- a/update.json
+++ b/update.json
@@ -1,8 +1,8 @@
 {
   "homepage": "https://github.com/Judge40/BetterMobGriefingGameRule/",
   "promos": {
-    "1.16.5-latest": "1.16.5-9.0.0",
-    "1.16.5-recommended": "1.16.5-9.0.0",
+    "1.16.5-latest": "1.16.5-9.0.1",
+    "1.16.5-recommended": "1.16.5-9.0.1",
     "1.16.3-latest": "1.16.3-8.0.4-beta",
     "1.16.1-latest": "1.16.1-8.0.3-alpha",
     "1.15.2-latest": "1.15.2-8.0.1",


### PR DESCRIPTION
The SmallFireballEntity uses itself instead of its owner due to a bug in MinecraftForge.
Add a workround to be removed once MinecraftForge #9038 is merged.