### PR TITLE
build: target Java 16 so bundled version matches

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -102,7 +102,7 @@ checkstyle {
 
 java {
   toolchain {
-    languageVersion = JavaLanguageVersion.of(17)
+    languageVersion = JavaLanguageVersion.of(16)
     vendor = JvmVendorSpec.ADOPTIUM
   }
 }


### PR DESCRIPTION
Minecraft's bundled Java version for 1.17-1.17.1 is Java 16, downgrade the targetted version to avoid incompatibility issues using the bundled version of Java.